### PR TITLE
CI 上の依存モジュールキャッシュ方法を変更

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,19 +15,14 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.12
+          cache: pipenv
+          cache-dependency-path: |
+            api/Pipfile.lock
 
       - name: Setup pipenv
         run: pip install pipenv
 
-      - name: Cache virtualenvs
-        uses: actions/cache@v4
-        id: api_cache
-        with:
-          path: ~/.local/share/virtualenvs
-          key: ${{ runner.OS }}-lib-${{ hashFiles('api/Pipfile.lock') }}
-
       - name: Install dependencies
-        if: steps.api_cache.outputs.cache-hit != 'true'
         run: pipenv install -d
 
       - name: Execute code check
@@ -45,19 +40,14 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.12
+          cache: pipenv
+          cache-dependency-path: |
+            generate_model/Pipfile.lock
 
       - name: Setup pipenv
         run: pip install pipenv
 
-      - name: Cache virtualenvs
-        uses: actions/cache@v4
-        id: generate_model_cache
-        with:
-          path: ~/.local/share/virtualenvs
-          key: ${{ runner.OS }}-lib-${{ hashFiles('generate_model/Pipfile.lock') }}
-
       - name: Install dependencies
-        if: steps.generate_model_cache.outputs.cache-hit != 'true'
         run: pipenv install -d
 
       - name: Execute code check

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -20,19 +20,14 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.12
+          cache: pipenv
+          cache-dependency-path: |
+            generate_model/Pipfile.lock
 
       - name: Setup pipenv
         run: pip install pipenv
 
-      - name: Cache virtualenvs
-        uses: actions/cache@v4
-        id: generate_model_cache
-        with:
-          path: ~/.local/share/virtualenvs
-          key: ${{ runner.OS }}-lib-${{ hashFiles('**/Pipfile.lock') }}
-
       - name: Install dependencies
-        if: steps.generate_model_cache.outputs.cache-hit != 'true'
         run: pipenv install -d
 
       - name: Execute


### PR DESCRIPTION
actions/cache を利用せず、actions/setup-python の cache オプションでキャッシュの保存・復元をするよう修正